### PR TITLE
Allow Windows builds using MSYS2 Environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -shared-libgcc -ggdb")
   set(CMAKE_LINK_FLAGS "-ggdb")
 endif()
+if(MSYS)
+  string(REPLACE "-fPIC" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  add_definitions(-D__USE_MINGW_ANSI_STDIO=1)
+endif()
 
 # Compilation database for Clang static analyzer
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
   set(CMAKE_LINK_FLAGS "-ggdb")
 endif()
 if(MSYS)
-  string(REPLACE "-fPIC" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+  string(REPLACE "-fPIC" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   add_definitions(-D__USE_MINGW_ANSI_STDIO=1)
 endif()
 

--- a/src/gp4prog/gp4prog.h
+++ b/src/gp4prog/gp4prog.h
@@ -31,20 +31,12 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-#include <libusb-1.0/libusb.h>
-
-//Windows appears to define an ERROR macro in its headers.
-//Conflicts with ERROR enum defined in log.h.
-#if defined(_WIN32) && defined(ERROR)
-	#undef ERROR
-#endif
-
 #include "../log/log.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // USB command wrappers
 
-typedef libusb_device_handle* hdevice;
+typedef struct libusb_device_handle* hdevice;
 
 void USBSetup();
 void USBCleanup(hdevice hdev);

--- a/src/gp4prog/gp4prog.h
+++ b/src/gp4prog/gp4prog.h
@@ -33,6 +33,12 @@
 
 #include <libusb-1.0/libusb.h>
 
+//Windows appears to define an ERROR macro in its headers.
+//Conflicts with ERROR enum defined in log.h.
+#if defined(_WIN32) && defined(ERROR)
+	#undef ERROR
+#endif
+
 #include "../log/log.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/gp4prog/usb.cpp
+++ b/src/gp4prog/usb.cpp
@@ -16,6 +16,14 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA                                      *
  **********************************************************************************************************************/
 
+#include <libusb-1.0/libusb.h>
+
+//Windows appears to define an ERROR macro in its headers.
+//Conflicts with ERROR enum defined in log.h.
+#if defined(_WIN32) && defined(ERROR)
+	#undef ERROR
+#endif
+
 #include "gp4prog.h"
 
 using namespace std;

--- a/src/greenpak4/Greenpak4Netlist.cpp
+++ b/src/greenpak4/Greenpak4Netlist.cpp
@@ -33,7 +33,7 @@ Greenpak4Netlist::Greenpak4Netlist(std::string fname)
 	: m_topModule(NULL)
 {
 	//Read the netlist
-	FILE* fp = fopen(fname.c_str(), "r");
+	FILE* fp = fopen(fname.c_str(), "rb");
 	if(fp == NULL)
 	{
 		LogError("Failed to open netlist file %s\n", fname.c_str());


### PR DESCRIPTION
Meant to file this weeks ago, but the following commits permit Windows builds using the MSYS2 environment.

The `doc` target doesn't work; there's a bug in MikTeX that prevents it from finding one of the 5000 packages required even though it exists on my path. My suggestion for now is to just `touch` an empty file to skip doc building.

I am making a pull request instead of committing directly to get feedback. Since you intend to replace the build system, this is a stopgap for now.
