### PR TITLE
gpdevboard: Don't exceed the usleep limit on certain platforms

### DIFF
--- a/src/gpdevboard/utils.cpp
+++ b/src/gpdevboard/utils.cpp
@@ -92,7 +92,8 @@ hdevice OpenBoard(int nboard, bool test)
 		if(hdev || !switching)
 			break;
 
-		usleep(1000 * 1000);
+		// usleep is only guaranteed to work with <1000000 us of sleeping
+		usleep(1000 * 1000 - 1);
 	}
 
 	//By this point, it should be in "orange" mode


### PR DESCRIPTION
Really fixes https://github.com/azonenberg/openfpga/issues/69 this time